### PR TITLE
Add ConfigureAwait(false) to async calls

### DIFF
--- a/Atlassian.Stash.Api/Api/Branches.cs
+++ b/Atlassian.Stash.Api/Api/Branches.cs
@@ -24,7 +24,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_BRANCHES, requestOptions, projectKey, repositorySlug);
 
-            ResponseWrapper<Branch> response = await _httpWorker.GetAsync<ResponseWrapper<Branch>>(requestUrl);
+            ResponseWrapper<Branch> response = await _httpWorker.GetAsync<ResponseWrapper<Branch>>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -34,7 +34,7 @@ namespace Atlassian.Stash.Api.Api
             string requestUrl = UrlBuilder.FormatRestApiUrl(BRANCHES_FOR_COMMIT, requestOptions, projectKey, repositorySlug,
                 commitId);
 
-            ResponseWrapper<Branch> response = await _httpWorker.GetAsync<ResponseWrapper<Branch>>(requestUrl);
+            ResponseWrapper<Branch> response = await _httpWorker.GetAsync<ResponseWrapper<Branch>>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -44,7 +44,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANAGE_BRANCHES, null, projectKey, repositorySlug);
 
-            Branch response = await _httpWorker.PostAsync(requestUrl, branch);
+            Branch response = await _httpWorker.PostAsync(requestUrl, branch).ConfigureAwait(false);
 
             return response;
         }
@@ -53,14 +53,14 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANAGE_BRANCHES, null, projectKey, repositorySlug);
 
-            await _httpWorker.DeleteWithRequestContentAsync(requestUrl, branch);
+            await _httpWorker.DeleteWithRequestContentAsync(requestUrl, branch).ConfigureAwait(false);
         }
 
         public async Task<BranchPermission> SetPermissions(string projectKey, string repositorySlug, BranchPermission permissions) 
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(BRANCH_PERMISSIONS, null, projectKey, repositorySlug);
 
-            BranchPermission response = await _httpWorker.PostAsync(requestUrl, permissions);
+            BranchPermission response = await _httpWorker.PostAsync(requestUrl, permissions).ConfigureAwait(false);
 
             return response;
         }
@@ -69,7 +69,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(BRANCH_DELETE_PERMISSIONS, null, projectKey, repositorySlug, permissionsId.ToString());
 
-            await _httpWorker.DeleteAsync(requestUrl);
+            await _httpWorker.DeleteAsync(requestUrl).ConfigureAwait(false);
         }
     }
 }

--- a/Atlassian.Stash.Api/Api/Commits.cs
+++ b/Atlassian.Stash.Api/Api/Commits.cs
@@ -23,7 +23,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_COMMITS, requestOptions, projectKey, repositorySlug);
 
-            ResponseWrapper<Commit> response = await _httpWorker.GetAsync<ResponseWrapper<Commit>>(requestUrl);
+            ResponseWrapper<Commit> response = await _httpWorker.GetAsync<ResponseWrapper<Commit>>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -32,7 +32,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_COMMIT, null, projectKey, repositorySlug, commitId);
 
-            Commit response = await _httpWorker.GetAsync<Commit>(requestUrl);
+            Commit response = await _httpWorker.GetAsync<Commit>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -46,7 +46,7 @@ namespace Atlassian.Stash.Api.Api
             else
                 requestUrl = UrlBuilder.FormatRestApiUrl(CHANGES_UNTIL_AND_SINCE, requestOptions, projectKey, repositorySlug, untilCommit, sinceCommit);
 
-            Changes response = await _httpWorker.GetAsync<Changes>(requestUrl);
+            Changes response = await _httpWorker.GetAsync<Changes>(requestUrl).ConfigureAwait(false);
 
             return response;
         }

--- a/Atlassian.Stash.Api/Api/Projects.cs
+++ b/Atlassian.Stash.Api/Api/Projects.cs
@@ -21,7 +21,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_PROJECTS, requestOptions);
 
-            ResponseWrapper<Project> response = await _httpWorker.GetAsync<ResponseWrapper<Project>>(requestUrl);
+            ResponseWrapper<Project> response = await _httpWorker.GetAsync<ResponseWrapper<Project>>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -30,7 +30,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_PROJECT, null, projectKey);
 
-            Project response = await _httpWorker.GetAsync<Project>(requestUrl);
+            Project response = await _httpWorker.GetAsync<Project>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -39,7 +39,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_PROJECTS);
 
-            Project response = await _httpWorker.PostAsync<Project>(requestUrl, project);
+            Project response = await _httpWorker.PostAsync<Project>(requestUrl, project).ConfigureAwait(false);
 
             return response;
         }
@@ -48,7 +48,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_PROJECT, null, projectKey);
 
-            await _httpWorker.DeleteAsync(requestUrl);
+            await _httpWorker.DeleteAsync(requestUrl).ConfigureAwait(false);
         }
     }
 }

--- a/Atlassian.Stash.Api/Api/Repositories.cs
+++ b/Atlassian.Stash.Api/Api/Repositories.cs
@@ -27,7 +27,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_REPOSITORIES, requestOptions, projectKey);
 
-            ResponseWrapper<Repository> response = await _httpWorker.GetAsync<ResponseWrapper<Repository>>(requestUrl);
+            ResponseWrapper<Repository> response = await _httpWorker.GetAsync<ResponseWrapper<Repository>>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -36,7 +36,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_REPOSITORY, null, projectKey, repositorySlug);
 
-            Repository response = await _httpWorker.GetAsync<Repository>(requestUrl);
+            Repository response = await _httpWorker.GetAsync<Repository>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -45,7 +45,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_REPOSITORIES, null, projectKey);
 
-            Repository response = await _httpWorker.PostAsync<Repository>(requestUrl, repository);
+            Repository response = await _httpWorker.PostAsync<Repository>(requestUrl, repository).ConfigureAwait(false);
 
             return response;
         }
@@ -54,14 +54,14 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_REPOSITORY, null, projectKey, repositorySlug);
 
-            await _httpWorker.DeleteAsync(requestUrl);
+            await _httpWorker.DeleteAsync(requestUrl).ConfigureAwait(false);
         }
 
         public async Task<ResponseWrapper<Tag>> GetTags(string projectKey, string repositorySlug, RequestOptions requestOptions = null)
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_TAGS, requestOptions, projectKey, repositorySlug);
 
-            ResponseWrapper<Tag> response = await _httpWorker.GetAsync<ResponseWrapper<Tag>>(requestUrl);
+            ResponseWrapper<Tag> response = await _httpWorker.GetAsync<ResponseWrapper<Tag>>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -70,7 +70,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_FILES, requestOptions, projectKey, repositorySlug);
 
-            ResponseWrapper<string> response = await _httpWorker.GetAsync<ResponseWrapper<string>>(requestUrl);
+            ResponseWrapper<string> response = await _httpWorker.GetAsync<ResponseWrapper<string>>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -78,7 +78,7 @@ namespace Atlassian.Stash.Api.Api
         public async Task<File> GetFileContents(string projectKey, string repositorySlug, string path, RequestOptions requestOptions = null)
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_FILE, requestOptions, projectKey, repositorySlug, path);
-            File response = await _httpWorker.GetAsync<File>(requestUrl);
+            File response = await _httpWorker.GetAsync<File>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -87,7 +87,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_HOOKS, requestOptions, projectKey, repositorySlug);
 
-            ResponseWrapper<Hook> response = await _httpWorker.GetAsync<ResponseWrapper<Hook>>(requestUrl);
+            ResponseWrapper<Hook> response = await _httpWorker.GetAsync<ResponseWrapper<Hook>>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -96,7 +96,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_HOOK, null, projectKey, repositorySlug, hookKey);
 
-            Hook response = await _httpWorker.GetAsync<Hook>(requestUrl);
+            Hook response = await _httpWorker.GetAsync<Hook>(requestUrl).ConfigureAwait(false);
 
             return response;
         }
@@ -106,7 +106,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(HOOK_ENABLE, null, projectKey, repositorySlug, hookKey);
 
-            Hook response = await _httpWorker.PutAsync<Hook>(requestUrl, null);
+            Hook response = await _httpWorker.PutAsync<Hook>(requestUrl, null).ConfigureAwait(false);
 
             return response;
         }
@@ -115,7 +115,7 @@ namespace Atlassian.Stash.Api.Api
         {
             string requestUrl = UrlBuilder.FormatRestApiUrl(HOOK_ENABLE, null, projectKey, repositorySlug, hookKey);
 
-            Hook response = await _httpWorker.DeleteWithResponseContentAsync<Hook>(requestUrl);
+            Hook response = await _httpWorker.DeleteWithResponseContentAsync<Hook>(requestUrl).ConfigureAwait(false);
 
             return response;
         }

--- a/Atlassian.Stash.Api/Workers/HttpCommunicationWorker.cs
+++ b/Atlassian.Stash.Api/Workers/HttpCommunicationWorker.cs
@@ -54,9 +54,9 @@ namespace Atlassian.Stash.Api.Workers
         {
             using (HttpClient httpClient = CreateHttpClient())
             {
-                HttpResponseMessage httpResponse = await httpClient.GetAsync(requestUrl);
+                HttpResponseMessage httpResponse = await httpClient.GetAsync(requestUrl).ConfigureAwait(false);
 
-                string json = await httpResponse.Content.ReadAsStringAsync();
+                string json = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 T response = JsonConvert.DeserializeObject<T>(json);
 
@@ -68,14 +68,14 @@ namespace Atlassian.Stash.Api.Workers
         {
             using (HttpClient httpClient = CreateHttpClient())
             {
-                HttpResponseMessage httpResponse = await httpClient.PostAsync<T>(requestUrl, data, new JsonMediaTypeFormatter());
+                HttpResponseMessage httpResponse = await httpClient.PostAsync<T>(requestUrl, data, new JsonMediaTypeFormatter()).ConfigureAwait(false);
 
                 if (httpResponse.StatusCode != HttpStatusCode.Created && httpResponse.StatusCode != HttpStatusCode.OK)
                 {
                     throw new Exception(string.Format("POST operation unsuccessful. Got HTTP status code '{0}'", httpResponse.StatusCode));
                 }
 
-                string json = await httpResponse.Content.ReadAsStringAsync();
+                string json = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 T response = JsonConvert.DeserializeObject<T>(json);
 
@@ -88,15 +88,15 @@ namespace Atlassian.Stash.Api.Workers
             using (HttpClient httpClient = CreateHttpClient())
             {
                 HttpResponseMessage httpResponse = (data != null) ?
-                                        await httpClient.PutAsync<T>(requestUrl, data, new JsonMediaTypeFormatter()) :
-                                        await httpClient.PutAsync(requestUrl, null);
+                                        await httpClient.PutAsync<T>(requestUrl, data, new JsonMediaTypeFormatter()).ConfigureAwait(false) :
+                                        await httpClient.PutAsync(requestUrl, null).ConfigureAwait(false);
 
                 if (httpResponse.StatusCode != HttpStatusCode.Created && httpResponse.StatusCode != HttpStatusCode.OK)
                 {
                     throw new Exception(string.Format("POST operation unsuccessful. Got HTTP status code '{0}'", httpResponse.StatusCode));
                 }
 
-                string json = await httpResponse.Content.ReadAsStringAsync();
+                string json = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 T response = JsonConvert.DeserializeObject<T>(json);
 
@@ -108,7 +108,7 @@ namespace Atlassian.Stash.Api.Workers
         {
             using (HttpClient httpClient = CreateHttpClient())
             {
-                HttpResponseMessage httpResponse = await httpClient.DeleteAsync(requestUrl);
+                HttpResponseMessage httpResponse = await httpClient.DeleteAsync(requestUrl).ConfigureAwait(false);
 
                 if (httpResponse.StatusCode != HttpStatusCode.NoContent && httpResponse.StatusCode != HttpStatusCode.Accepted)
                 {
@@ -124,7 +124,7 @@ namespace Atlassian.Stash.Api.Workers
                 var requestMessage = new HttpRequestMessage(HttpMethod.Delete, requestUrl);
 
 
-                HttpResponseMessage httpResponse = await httpClient.SendAsync(requestMessage);
+                HttpResponseMessage httpResponse = await httpClient.SendAsync(requestMessage).ConfigureAwait(false);
 
 
                 if (httpResponse.StatusCode != HttpStatusCode.NoContent && httpResponse.StatusCode != HttpStatusCode.Accepted && httpResponse.StatusCode != HttpStatusCode.OK)
@@ -132,7 +132,7 @@ namespace Atlassian.Stash.Api.Workers
                     throw new Exception(string.Format("DELETE operation unsuccessful! Got HTTP status code '{0}'", httpResponse.StatusCode));
                 }
 
-                string json = await httpResponse.Content.ReadAsStringAsync();
+                string json = await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 T response = JsonConvert.DeserializeObject<T>(json);
 
@@ -150,7 +150,7 @@ namespace Atlassian.Stash.Api.Workers
 
                 requestMessage.Content = new StringContent(jsonData, System.Text.Encoding.UTF8, "application/json");
 
-                HttpResponseMessage httpResponse = await httpClient.SendAsync(requestMessage);
+                HttpResponseMessage httpResponse = await httpClient.SendAsync(requestMessage).ConfigureAwait(false);
 
 
                 if (httpResponse.StatusCode != HttpStatusCode.NoContent && httpResponse.StatusCode != HttpStatusCode.Accepted)


### PR DESCRIPTION
The async API calls cause deadlocks as written when used from synchronous code. To make it so that the Stash client can be used from both async and synch code, the internal async calls need to include  .ConfigureAwait(false).

Easy way to reproduce dead lock is to use current version (1.0.17) and call from a synchronous Web API controller.

    public HttpResponseMessage Get()
    {
        var stashClient = new StashClient("localhost:7990", "username", "password");
        var projects = stashClient.Projects.Get().Result;
        return Request.CreateResponse(HttpStatusCode.OK, projects);
    }

This is fixable in the controller by doing:

    public HttpResponseMessage Get()
    {
        var stashClient = new StashClient("localhost:7990", "username", "password");
        var projects = Task.Run(() => stashClient.Projects.Get()).Result;
        return Request.CreateResponse(HttpStatusCode.OK, projects);
    }

However, adding the .ConfigureAwait(false) inside the client dll will protect end users.