### PR TITLE
add support for getting file from specific branch

### DIFF
--- a/src/Atlassian.Stash/Api/Repositories.cs
+++ b/src/Atlassian.Stash/Api/Repositories.cs
@@ -14,6 +14,7 @@ namespace Atlassian.Stash.Api
         private const string ONE_TAG = "rest/git/1.0/projects/{0}/repos/{1}/tags/{2}";
         private const string MANY_FILES = "rest/api/1.0/projects/{0}/repos/{1}/files";
         private const string ONE_FILE = "rest/api/1.0/projects/{0}/repos/{1}/browse/{2}";
+        private const string ONE_FILE_FROM_BRANCH = "rest/api/1.0/projects/{0}/repos/{1}/browse/{2}?at=refs%2Fheads%2F{3}";
         private const string MANY_HOOKS = "rest/api/1.0/projects/{0}/repos/{1}/settings/hooks";
         private const string ONE_HOOK = "rest/api/1.0/projects/{0}/repos/{1}/settings/hooks/{2}";
         private const string HOOK_ENABLE = "rest/api/1.0/projects/{0}/repos/{1}/settings/hooks/{2}/enabled";
@@ -133,10 +134,20 @@ namespace Atlassian.Stash.Api
         public async Task<File> GetFileContents(string projectKey, string repositorySlug, string path, RequestOptions requestOptions = null)
         {
             // must espace spaces, but can't escape slashes
-
+            
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_FILE, false, requestOptions, projectKey, repositorySlug, path);
             File response = await _httpWorker.GetAsync<File>(requestUrl).ConfigureAwait(false);
+            
+            return response;
+        }
 
+        public async Task<File> GetFileContents(string projectKey, string repositorySlug, string path, string branch, RequestOptions requestOptions = null)
+        {
+            // must escape spaces, but can't escape slashes
+            
+            string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_FILE_FROM_BRANCH, false, requestOptions, projectKey, repositorySlug, path, branch);
+            File response = await _httpWorker.GetAsync<File>(requestUrl).ConfigureAwait(false);
+            
             return response;
         }
 

--- a/test/Atlassian.Stash.IntegrationTests/StashClientTester.cs
+++ b/test/Atlassian.Stash.IntegrationTests/StashClientTester.cs
@@ -43,6 +43,16 @@ namespace Atlassian.Stash.IntegrationTests
         }
 
         [TestMethod]
+        public async Task Can_GetFileContents_From_Branch()
+        {
+            var response = await stashClient.Repositories.GetFileContents(EXISTING_PROJECT, EXISTING_REPOSITORY, EXISTING_FILE, EXISTING_BRANCH_NAME);
+            
+            Assert.IsNotNull(response);
+            Assert.IsTrue(response.FileContents.Count > 0);
+            Assert.AreEqual(1, response.Size);
+        }
+        
+        [TestMethod]
         public async Task Can_GetBranchesForCommit()
         {
             var response = await stashClient.Branches.GetByCommitId(EXISTING_PROJECT, EXISTING_REPOSITORY, EXISTING_COMMIT);

--- a/test/Atlassian.Stash.IntegrationTests/TestBase.cs
+++ b/test/Atlassian.Stash.IntegrationTests/TestBase.cs
@@ -18,6 +18,7 @@ namespace Atlassian.Stash.IntegrationTests
         protected readonly string EXISTING_COMMIT = ConfigurationManager.AppSettings.Get("existing-commit");
         protected readonly string EXISTING_OLDER_COMMIT = ConfigurationManager.AppSettings.Get("existing-older-commit");
         protected readonly string EXISTING_BRANCH_REFERENCE = ConfigurationManager.AppSettings.Get("existing-branch-reference");
+        protected readonly string EXISTING_BRANCH_NAME = ConfigurationManager.AppSettings.Get("existing-branch-name");
         protected readonly string EXISTING_GROUP = ConfigurationManager.AppSettings.Get("existing-group");
         protected readonly string EXISTING_HOOK = ConfigurationManager.AppSettings.Get("existing-hook");
         protected readonly int EXISTING_NUMBER_OF_CHANGES = int.Parse(ConfigurationManager.AppSettings.Get("existing-number-of-changes"));


### PR DESCRIPTION
The `GetFileContents(...)` method now accepts another parameter `branch` if the user wants to specify which branch they would like to get the file from.