### PR TITLE
Add support for 2 more APIs

### DIFF
--- a/src/Atlassian.Stash.Net40/Properties/AssemblyInfo.cs
+++ b/src/Atlassian.Stash.Net40/Properties/AssemblyInfo.cs
@@ -32,9 +32,9 @@ using System.Runtime.CompilerServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.2.0")]
-[assembly: AssemblyFileVersion("0.1.2.0")]
-[assembly: AssemblyInformationalVersion("0.1.2-alpha")]
+[assembly: AssemblyVersion("3.0.12.0")]
+[assembly: AssemblyFileVersion("3.0.12.0")]
+[assembly: AssemblyInformationalVersion("3.0.12")]
 
 // Expose internals to UnitTests project
 [assembly: InternalsVisibleTo("Atlassian.Stash.UnitTests.Net40")]

--- a/src/Atlassian.Stash.Net45/Properties/AssemblyInfo.cs
+++ b/src/Atlassian.Stash.Net45/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("3.0.12.0")]
+[assembly: AssemblyFileVersion("3.0.12.0")]
 
 // Expose internals to UnitTests project
 [assembly: InternalsVisibleTo("Atlassian.Stash.UnitTests")]

--- a/src/Atlassian.Stash/Api/Branches.cs
+++ b/src/Atlassian.Stash/Api/Branches.cs
@@ -8,6 +8,7 @@ namespace Atlassian.Stash.Api
     public class Branches
     {
         private const string MANY_BRANCHES = "rest/api/1.0/projects/{0}/repos/{1}/branches";
+        private const string BRANCHES_DEFAULT = "rest/api/1.0/projects/{0}/repos/{1}/branches/default";
         private const string MANY_BRANCHES_WITH_FILTER = "rest/api/1.0/projects/{0}/repos/{1}/branches?filterText={2}";
         private const string MANAGE_BRANCHES = "rest/branch-utils/1.0/projects/{0}/repos/{1}/branches";
         private const string BRANCHES_FOR_COMMIT = "rest/branch-utils/1.0/projects/{0}/repos/{1}/branches/info/{2}";
@@ -89,6 +90,24 @@ namespace Atlassian.Stash.Api
             string requestUrl = UrlBuilder.FormatRestApiUrl(BRANCH_DELETE_PERMISSIONS, null, projectKey, repositorySlug, permissionsId.ToString());
 
             await _httpWorker.DeleteAsync(requestUrl).ConfigureAwait(false);
+        }
+
+        public async Task<Branch> GetDefault(string projectKey, string repositorySlug)
+        {
+            string requestUrl = UrlBuilder.FormatRestApiUrl(BRANCHES_DEFAULT, null, projectKey, repositorySlug);
+
+            Branch response = await _httpWorker.GetAsync<Branch>(requestUrl).ConfigureAwait(false);
+
+            return response;
+        }
+
+        public async Task<Branch> SetDefault(string projectKey, string repositorySlug, Branch branch)
+        {
+            string requestUrl = UrlBuilder.FormatRestApiUrl(BRANCHES_DEFAULT, null, projectKey, repositorySlug);
+
+            Branch response = await _httpWorker.PutAsync(requestUrl, branch).ConfigureAwait(false);
+
+            return response;
         }
     }
 }

--- a/src/Atlassian.Stash/Api/Repositories.cs
+++ b/src/Atlassian.Stash/Api/Repositories.cs
@@ -16,6 +16,7 @@ namespace Atlassian.Stash.Api
         private const string ONE_FILE = "rest/api/1.0/projects/{0}/repos/{1}/browse/{2}";
         private const string ONE_FILE_FROM_BRANCH = "rest/api/1.0/projects/{0}/repos/{1}/browse/{2}?at=refs%2Fheads%2F{3}";
         private const string MANY_HOOKS = "rest/api/1.0/projects/{0}/repos/{1}/settings/hooks";
+        private const string PULLREQUEST_SETTINGS = "rest/api/1.0/projects/{0}/repos/{1}/settings/pull-requests";
         private const string ONE_HOOK = "rest/api/1.0/projects/{0}/repos/{1}/settings/hooks/{2}";
         private const string HOOK_ENABLE = "rest/api/1.0/projects/{0}/repos/{1}/settings/hooks/{2}/enabled";
         private const string HOOK_SETTINGS = "rest/api/1.0/projects/{0}/repos/{1}/settings/hooks/{2}/settings";
@@ -202,6 +203,24 @@ namespace Atlassian.Stash.Api
             string requestUrl = UrlBuilder.FormatRestApiUrl(HOOK_SETTINGS, null, projectKey, repositorySlug, hookKey);
 
             string response = await _httpWorker.PutAsync(requestUrl, settings).ConfigureAwait(false);
+
+            return response;
+        }
+
+        public async Task<PullRequestSettings> GetPullRequestSettings(string projectKey, string repositorySlug)
+        {
+            string requestUrl = UrlBuilder.FormatRestApiUrl(PULLREQUEST_SETTINGS, null, projectKey, repositorySlug);
+
+            PullRequestSettings response = await _httpWorker.GetAsync<PullRequestSettings>(requestUrl).ConfigureAwait(false);
+
+            return response;
+        }
+
+        public async Task<PullRequestSettings> SetPullRequestSettings(string projectKey, string repositorySlug, PullRequestSettings settings)
+        {
+            string requestUrl = UrlBuilder.FormatRestApiUrl(PULLREQUEST_SETTINGS, null, projectKey, repositorySlug);
+
+            PullRequestSettings response = await _httpWorker.PostAsync<PullRequestSettings>(requestUrl, settings, true).ConfigureAwait(false);
 
             return response;
         }

--- a/src/Atlassian.Stash/Atlassian.Stash.projitems
+++ b/src/Atlassian.Stash/Atlassian.Stash.projitems
@@ -38,6 +38,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Entities\Permission.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Entities\Project.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Entities\PullRequest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Entities\PullRequestSettings.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Entities\Ref.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Entities\Repository.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Entities\Self.cs" />

--- a/src/Atlassian.Stash/Entities/Branch.cs
+++ b/src/Atlassian.Stash/Entities/Branch.cs
@@ -5,6 +5,7 @@ namespace Atlassian.Stash.Entities
     // todo: Review class, since Create != Get != Delete objects
     public class Branch
     {
+        [JsonProperty("id")]
         public string Id { get; set; }
         public string DisplayId { get; set; }
         public string LatestChangeset { get; set; }

--- a/src/Atlassian.Stash/Entities/PullRequestSettings.cs
+++ b/src/Atlassian.Stash/Entities/PullRequestSettings.cs
@@ -1,0 +1,71 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Atlassian.Stash.Entities
+{
+    public class PullRequestSettings
+    {
+        [JsonProperty("mergeConfig")]
+        public MergeConfig MergeConfig { get; set; }
+
+        [JsonProperty("requiredAllApprovers")]
+        public bool RequiredAllApprovers { get; set; }
+
+        [JsonProperty("requiredAllTasksComplete")]
+        public bool RequiredAllTasksComplete { get; set; }
+
+        [JsonProperty("requiredApprovers")]
+        public int RequiredApprovers { get; set; }
+
+        [JsonProperty("requiredSuccessfulBuilds")]
+        public int RequiredSuccessfulBuilds { get; set; }
+    }
+
+    public class MergeConfig
+    {
+        [JsonProperty("defaultStrategy")]
+        public Strategy DefaultStrategy { get; set; }
+
+        [JsonProperty("strategies")]
+        public List<Strategy> Strategies { get; set; }
+
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+
+    public class Strategy
+    {
+        [JsonProperty("description")]
+        public string Description { get; set; }
+
+        [JsonProperty("enabled")]
+        public bool? Enabled { get; set; }
+
+        [JsonProperty("flag")]
+        public string Flag { get; set; }
+
+        [JsonProperty("id")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public StrategyIdType Id { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+
+    public enum StrategyIdType
+    {
+        [EnumMember(Value = "no-ff")]
+        NO_FAST_FORWARD,
+        [EnumMember(Value = "ff-only")]
+        FAST_FORWARD_ONLY,
+        [EnumMember(Value = "squash-ff-only")]
+        SQUASH_FAST_FORWARD_ONLY,
+        [EnumMember(Value = "ff")]
+        FAST_FORWARD,
+        [EnumMember(Value = "squash")]
+        SQUASH,
+    }
+
+}

--- a/test/Atlassian.Stash.IntegrationTests/StashClientTester.cs
+++ b/test/Atlassian.Stash.IntegrationTests/StashClientTester.cs
@@ -207,6 +207,59 @@ namespace Atlassian.Stash.IntegrationTests
         }
 
         [TestMethod]
+        public async Task Can_GetPullRequestSettings()
+        {
+            var response = await stashClient.Repositories.GetPullRequestSettings(EXISTING_PROJECT, EXISTING_REPOSITORY);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.MergeConfig);
+            Assert.IsNotNull(response.MergeConfig.DefaultStrategy);
+            Assert.IsNotNull(response.MergeConfig.Strategies);
+            Assert.IsNotNull(response.MergeConfig.Type = "REPOSITORY");
+            Assert.IsNotNull(response.RequiredApprovers = 0);
+
+        }
+
+        [TestMethod]
+        public async Task Can_SetPullRequestSettings()
+        {
+            var originalSettings = await stashClient.Repositories.GetPullRequestSettings(EXISTING_PROJECT, EXISTING_REPOSITORY);
+
+            var settings = new PullRequestSettings
+            {
+                MergeConfig = new MergeConfig
+                {
+                    DefaultStrategy = new Strategy {Id = StrategyIdType.SQUASH_FAST_FORWARD_ONLY},
+                    Strategies = new List<Strategy>
+                    {
+                        new Strategy {Id = StrategyIdType.SQUASH_FAST_FORWARD_ONLY},
+                        new Strategy {Id = StrategyIdType.NO_FAST_FORWARD}
+                    }
+                },
+                RequiredAllApprovers = false,
+                RequiredAllTasksComplete = false,
+                RequiredApprovers = 2,
+                RequiredSuccessfulBuilds = 1
+            };
+
+            await stashClient.Repositories.SetPullRequestSettings(EXISTING_PROJECT, EXISTING_REPOSITORY, settings);
+
+            var response = await stashClient.Repositories.GetPullRequestSettings(EXISTING_PROJECT, EXISTING_REPOSITORY);
+
+            Assert.IsNotNull(response);
+            Assert.IsNotNull(response.MergeConfig);
+            Assert.IsNotNull(response.MergeConfig.DefaultStrategy);
+            Assert.IsNotNull(response.MergeConfig.DefaultStrategy.Id = StrategyIdType.SQUASH_FAST_FORWARD_ONLY);
+            Assert.IsNotNull(response.MergeConfig.Strategies);
+            Assert.AreEqual(2, response.MergeConfig.Strategies.Count(s => s.Enabled != null && s.Enabled.Value));
+            Assert.AreEqual(2, response.RequiredApprovers);
+            Assert.AreEqual(1, response.RequiredSuccessfulBuilds);
+
+            await stashClient.Repositories.SetPullRequestSettings(EXISTING_PROJECT, EXISTING_REPOSITORY, originalSettings);
+
+        }
+
+        [TestMethod]
         public async Task Can_GetAllBranches()
         {
             var response = await stashClient.Branches.Get(EXISTING_PROJECT, EXISTING_REPOSITORY);

--- a/test/Atlassian.Stash.IntegrationTests/StashClientTester.cs
+++ b/test/Atlassian.Stash.IntegrationTests/StashClientTester.cs
@@ -447,7 +447,27 @@ namespace Atlassian.Stash.IntegrationTests
             Assert.AreEqual(EXISTING_HOOK, response.Details.Key);
         }
 
-        #region Feature tests
+        [TestMethod]
+        public async Task Can_SetDefaultBranch_Than_RetrieveIt()
+        {
+            var response = await stashClient.Branches.GetDefault(EXISTING_PROJECT, EXISTING_REPOSITORY);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual("refs/heads/master", response.Id);
+
+            var defaultBranch = new Branch { Id = "refs/heads/develop" };
+
+            await stashClient.Branches.SetDefault(EXISTING_PROJECT, EXISTING_REPOSITORY, defaultBranch);
+
+            response = await stashClient.Branches.GetDefault(EXISTING_PROJECT, EXISTING_REPOSITORY);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual("refs/heads/develop", response.Id);
+
+            defaultBranch = new Branch { Id = "refs/heads/master" };
+
+            await stashClient.Branches.SetDefault(EXISTING_PROJECT, EXISTING_REPOSITORY, defaultBranch);
+        }
 
         [TestMethod]
         public async Task Can_GetBranchPermissions()
@@ -606,7 +626,5 @@ namespace Atlassian.Stash.IntegrationTests
             Assert.IsInstanceOfType(deletedUser, typeof(User));
             Assert.AreEqual("tmpTestUser", deletedUser.Name);
         }
-
-        #endregion
     }
 }


### PR DESCRIPTION

- Add support for /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/branches/default [GET, PUT]
- Add support for /rest/api/1.0/projects/{projectKey}/repos/{repositorySlug}/settings/pull-requests [GET, PUT]
- Fix Branch Id serialization: Id => id