### PR TITLE
Add Support for Path in Repository.GetFiles (#51)

### DIFF
--- a/src/Atlassian.Stash/Api/Repositories.cs
+++ b/src/Atlassian.Stash/Api/Repositories.cs
@@ -13,6 +13,7 @@ namespace Atlassian.Stash.Api
         private const string MANY_TAGS = "rest/api/1.0/projects/{0}/repos/{1}/tags";
         private const string ONE_TAG = "rest/git/1.0/projects/{0}/repos/{1}/tags/{2}";
         private const string MANY_FILES = "rest/api/1.0/projects/{0}/repos/{1}/files";
+        private const string MANY_FILES_FROM_PATH = "rest/api/1.0/projects/{0}/repos/{1}/files/{2}";
         private const string ONE_FILE = "rest/api/1.0/projects/{0}/repos/{1}/browse/{2}";
         private const string ONE_FILE_FROM_BRANCH = "rest/api/1.0/projects/{0}/repos/{1}/browse/{2}?at=refs%2Fheads%2F{3}";
         private const string MANY_HOOKS = "rest/api/1.0/projects/{0}/repos/{1}/settings/hooks";
@@ -121,6 +122,15 @@ namespace Atlassian.Stash.Api
             string requestUrl = UrlBuilder.FormatRestApiUrl(ONE_TAG, null, projectKey, repositorySlug, tagName);
 
             await _httpWorker.DeleteAsync(requestUrl).ConfigureAwait(false);
+        }
+
+        public async Task<ResponseWrapper<string>> GetFiles(string projectKey, string repositorySlug, string path, RequestOptions requestOptions = null)
+        {
+            string requestUrl = UrlBuilder.FormatRestApiUrl(MANY_FILES_FROM_PATH, false, requestOptions, projectKey, repositorySlug, path);
+
+            ResponseWrapper<string> response = await _httpWorker.GetAsync<ResponseWrapper<string>>(requestUrl).ConfigureAwait(false);
+
+            return response;
         }
 
         public async Task<ResponseWrapper<string>> GetFiles(string projectKey, string repositorySlug, RequestOptions requestOptions = null)

--- a/test/Atlassian.Stash.IntegrationTests/App.config
+++ b/test/Atlassian.Stash.IntegrationTests/App.config
@@ -11,6 +11,7 @@
     <add key="existing-file" value="test.txt" />
     <add key="existing-file-in-subfolder" value="folder/test.txt" />
     <add key="existing-file-in-subfolder-with-spaces" value="my folder/my test.txt" />
+    <add key="existing-folder" value="folder"/>
     <add key="existing-commit" value="ef69fc055ea7f5d854dba1a3389e39b025c6a559" />
     <add key="existing-older-commit" value="ef69fc055ea7f5d854dba1a3389e39b025c6a559" />
     <add key="existing-number-of-changes" value="1" />

--- a/test/Atlassian.Stash.IntegrationTests/StashClientTester.cs
+++ b/test/Atlassian.Stash.IntegrationTests/StashClientTester.cs
@@ -186,6 +186,17 @@ namespace Atlassian.Stash.IntegrationTests
         }
 
         [TestMethod]
+        public async Task Can_GetFilesInSubFolder()
+        {
+            var response = await stashClient.Repositories.GetFiles(EXISTING_PROJECT, EXISTING_REPOSITORY, EXISTING_FOLDER);
+            var files = response.Values;
+
+            Assert.IsNotNull(files);
+            Assert.IsInstanceOfType(files, typeof(IEnumerable<string>));
+            Assert.IsTrue(files.Any());
+        }
+
+        [TestMethod]
         public async Task Can_GetAllFiles()
         {
             var response = await stashClient.Repositories.GetFiles(EXISTING_PROJECT, EXISTING_REPOSITORY);

--- a/test/Atlassian.Stash.IntegrationTests/TestBase.cs
+++ b/test/Atlassian.Stash.IntegrationTests/TestBase.cs
@@ -13,6 +13,7 @@ namespace Atlassian.Stash.IntegrationTests
         protected readonly string EXISTING_PROJECT = ConfigurationManager.AppSettings.Get("existing-project");
         protected readonly string EXISTING_REPOSITORY = ConfigurationManager.AppSettings.Get("existing-repository");
         protected readonly string EXISTING_FILE = ConfigurationManager.AppSettings.Get("existing-file");
+        protected readonly string EXISTING_FOLDER = ConfigurationManager.AppSettings.Get("existing-folder");
         protected readonly string EXISTING_FILE_IN_SUBFOLDER = ConfigurationManager.AppSettings.Get("existing-file-in-subfolder");
         protected readonly string EXISTING_FILE_IN_SUBFOLDER_WITH_SPACES = ConfigurationManager.AppSettings.Get("existing-file-in-subfolder-with-spaces");
         protected readonly string EXISTING_COMMIT = ConfigurationManager.AppSettings.Get("existing-commit");


### PR DESCRIPTION
Add an overload for Repository.GetFiles that has a path parameter so you can get files from a directory within a repo instead of the entire file list.