### PR TITLE
Bug in UrlBuilder.FormatRestApiUrlWithCommitOptions for paged results

### DIFF
--- a/src/Atlassian.Stash/Helpers/UrlBuilder.cs
+++ b/src/Atlassian.Stash/Helpers/UrlBuilder.cs
@@ -164,7 +164,7 @@ namespace Atlassian.Stash.Helpers
             if (commitRequestOptions != null)
             {
                 string partialUrl = "";
-                bool urlHasQueryParams = restUrl.IndexOf('?') > -1;
+                bool urlHasQueryParams = resultingUrl.IndexOf('?') > -1;
 
                 if (!string.IsNullOrWhiteSpace(commitRequestOptions.Path))
                 {

--- a/test/Atlassian.Stash.UnitTests/UrlBuilderTests.cs
+++ b/test/Atlassian.Stash.UnitTests/UrlBuilderTests.cs
@@ -169,5 +169,13 @@ namespace Atlassian.Stash.UnitTests
 
             Assert.AreEqual("none", actual);
         }
+
+        [TestMethod]
+        public void FormatRestApiUrl_RequestOptionsForCommits()
+        {
+            string actual = UrlBuilder.FormatRestApiUrlWithCommitOptions("none", new RequestOptions { Limit = 1, Start = 25 }, new RequestOptionsForCommits { Since = "abc", Until = "def" });
+
+            Assert.AreEqual("none?limit=1&start=25&since=abc&until=def", actual);
+        }
     }
 }


### PR DESCRIPTION
Added failing test for UrlBuilder.FormatRestApiUrlWithCommitOptions
Then fixed the bug